### PR TITLE
Modified the shebang to allow this to work in virtualenvs

### DIFF
--- a/enumall.py
+++ b/enumall.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # enumall is a refactor of enumall.sh providing a script to identify subdomains using several techniques and tools.
 # Relying heavily on the stellar Recon-NG framework and Alt-DNS, enumall will identify subdomains via search engine
@@ -6,7 +6,7 @@
 # concatenated subdomains (altDNS), and brute-forces with a stellar subdomain list (formed from Bitquark's subdomain
 # research, Seclists, Knock, Fierce, Recon-NG, and more) located here:
 # https://github.com/danielmiessler/SecLists/blob/master/Discovery/DNS/sorted_knock_dnsrecon_fierce_recon-ng.txt
-# 
+#
 # Alt-DNS Download: https://github.com/infosec-au/altdns
 #
 # by @jhaddix and @leifdreizler
@@ -43,11 +43,11 @@ def run_recon(domains, bruteforce):
 	reconb.init_workspace(wspace)
 	reconb.onecmd("TIMEOUT=100")
 	module_list = ["recon/domains-hosts/bing_domain_web", "recon/domains-hosts/google_site_web", "recon/domains-hosts/netcraft", "recon/domains-hosts/shodan_hostname", "recon/netblocks-companies/whois_orgs", "recon/hosts-hosts/resolve"]
-	
+
 	for domain in domains:
 		for module in module_list:
 	    		run_module(reconb, module, domain)
-	
+
 		#subdomain bruteforcing
 		x = reconb.do_load("recon/domains-hosts/brute_hosts")
 		if bruteforce:
@@ -56,7 +56,7 @@ def run_recon(domains, bruteforce):
 			x.do_set("WORDLIST /usr/share/recon-ng/data/hostnames.txt")
 		x.do_set("SOURCE " + domain)
 		x.do_run(None)
-	
+
 	#reporting output
 	outFile = "FILENAME "+os.getcwd()+"/"+domains[0]
 	x = reconb.do_load("reporting/csv")
@@ -90,7 +90,7 @@ if args.filename:
 	lines = [line.rstrip('\n') for line in lines]
 	domainList+=lines
 
-bruteforceList = args.wordlist.name if args.wordlist else ""	
+bruteforceList = args.wordlist.name if args.wordlist else ""
 
 run_recon(domainList, bruteforceList)
 


### PR DESCRIPTION
Modified the shebang to allow this to work in virtualenvs and non-standard python installations.

The current shebang `#!/usr/bin/python` assumes that is the location of the correct env python, however on my mac I'm using this wrapper `~/.virtualenvs/recon/bin/python`.

This causes silent module load errors for `google_site_web` because the dependent libs can't be resolved using the global python binary.

Should fix this issue: https://github.com/jhaddix/domain/issues/14